### PR TITLE
Fix ModuleNotFoundError in main.py and add clustering tests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -87,29 +87,29 @@ if 'feature_generation_errors' not in st.session_state: # Initialize new state f
 
 # --- Imports for modules (will be used later but good to have grouped) ---
 import matplotlib.pyplot as plt
-from src.database import connect_postgres, get_schemas_postgres, get_tables_postgres, fetch_data_postgres
-from src.analysis_modules.profiling import (
+from database import connect_postgres, get_schemas_postgres, get_tables_postgres, fetch_data_postgres
+from analysis_modules.profiling import (
     get_series_summary_stats,
     get_missing_values_summary,
     perform_stationarity_test
 )
-from src.analysis_modules.decomposition import decompose_time_series
-from src.analysis_modules.anomalies import (
+from analysis_modules.decomposition import decompose_time_series
+from analysis_modules.anomalies import (
     detect_anomalies_zscore,
     detect_anomalies_iqr,
     # detect_anomalies_isolation_forest, # Now part of AnomalyDetectionAnalysisModule
     # detect_anomalies_one_class_svm, # Now part of AnomalyDetectionAnalysisModule
     AnomalyDetectionAnalysisModule
 )
-from src.analysis_modules.feature_engineering import generate_all_features_for_series, run_feature_engineering_for_all_devices
-from src.analysis_modules.clustering import (
+from analysis_modules.feature_engineering import generate_all_features_for_series, run_feature_engineering_for_all_devices
+from analysis_modules.clustering import (
     perform_kmeans_clustering,
     # perform_kmeans_clustering, # Now part of ClusteringAnalysisModule
     # get_kmeans_elbow_silhouette_data, # Now part of ClusteringAnalysisModule
     # perform_dbscan_clustering, # Now part of ClusteringAnalysisModule
     ClusteringAnalysisModule
 )
-from src.analysis_modules.explainability import (
+from analysis_modules.explainability import (
     get_cluster_feature_summary,
     get_feature_importance_for_clusters_anova,
     compare_anomalous_vs_normal_features,
@@ -118,7 +118,7 @@ from src.analysis_modules.explainability import (
     explain_anomalies_with_surrogate_model
 )
 from sklearn.tree import plot_tree # For visualizing surrogate tree
-from src.config_utils import (
+from config_utils import (
     gather_settings_for_save,
     apply_loaded_settings_to_session_state,
     # Assuming these key lists are defined in config_utils as per previous setup

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -12,11 +12,121 @@ def test_module_metadata_simple():
     assert len(module.get_description()) > 0
     assert isinstance(module, AnalysisModuleInterface)
 
+# Fixture for sample data
+@pytest.fixture
+def sample_feature_df():
+    """Create a sample DataFrame for clustering tests."""
+    rng = np.random.RandomState(42)
+    n_samples = 30 # Reduced for faster tests
+    n_features = 4
+    data = rng.rand(n_samples, n_features)
+    df = pd.DataFrame(data, columns=[f'feature_{j}' for j in range(n_features)])
+    df.index = [f"device_{i}" for i in range(n_samples)]
+    # Add some structure for clustering
+    df.iloc[0:10, 0:2] += 2  # Group 1
+    df.iloc[10:20, 0:2] -= 2 # Group 2
+    # Group 3 is the rest
+    return df
+
+def test_perform_kmeans_clustering_basic(sample_feature_df):
+    from src.analysis_modules.clustering import perform_kmeans_clustering
+    n_clusters = 3
+    labels, model, error = perform_kmeans_clustering(sample_feature_df, n_clusters=n_clusters, random_state=42)
+
+    assert error is None
+    assert labels is not None
+    assert model is not None
+    assert len(labels) == len(sample_feature_df)
+    assert len(np.unique(labels)) == n_clusters
+    assert isinstance(labels, pd.Series)
+    assert hasattr(model, 'cluster_centers_')
+
+def test_perform_kmeans_clustering_scale_data(sample_feature_df):
+    from src.analysis_modules.clustering import perform_kmeans_clustering
+    n_clusters = 3
+    # Test with scaling
+    labels_scaled, _, error_scaled = perform_kmeans_clustering(sample_feature_df, n_clusters=n_clusters, scale_data=True, random_state=42)
+    assert error_scaled is None
+    assert labels_scaled is not None
+    assert len(np.unique(labels_scaled)) <= n_clusters # Scaling might change exact number of clusters found if some become empty
+
+    # Test without scaling
+    labels_unscaled, _, error_unscaled = perform_kmeans_clustering(sample_feature_df, n_clusters=n_clusters, scale_data=False, random_state=42)
+    assert error_unscaled is None
+    assert labels_unscaled is not None
+
+def test_perform_kmeans_clustering_edge_cases(sample_feature_df):
+    from src.analysis_modules.clustering import perform_kmeans_clustering
+    # Empty DataFrame
+    labels, model, error = perform_kmeans_clustering(pd.DataFrame(), n_clusters=2)
+    assert "Input DataFrame is empty" in error
+    assert labels is None
+    assert model is None
+
+    # NaN DataFrame
+    nan_df = sample_feature_df.copy()
+    nan_df.iloc[0,0] = np.nan
+    labels, model, error = perform_kmeans_clustering(nan_df, n_clusters=2)
+    assert "Input DataFrame contains NaN values" in error
+    assert labels is None
+    assert model is None
+
+    # n_clusters too high
+    labels, model, error = perform_kmeans_clustering(sample_feature_df, n_clusters=len(sample_feature_df) + 1)
+    assert f"Number of clusters ({len(sample_feature_df) + 1}) cannot exceed number of samples ({len(sample_feature_df)})" in error
+    assert labels is None
+    assert model is None
+
+    # n_clusters zero or negative
+    labels, model, error = perform_kmeans_clustering(sample_feature_df, n_clusters=0)
+    assert "Number of clusters (n_clusters) must be positive" in error
+
+def test_get_kmeans_elbow_silhouette_data(sample_feature_df):
+    from src.analysis_modules.clustering import get_kmeans_elbow_silhouette_data
+    # Ensure sample_feature_df has enough samples for the default k_range (2-10)
+    # If sample_feature_df has < 10 samples, this test might fail due to k_range check
+    # For this fixture, n_samples = 30, so it's fine.
+
+    # Make sure k_range is valid for the number of samples
+    max_k_test = min(10, len(sample_feature_df) -1)
+    if max_k_test < 2:
+        pytest.skip("Not enough samples for k-means stats range test after considering max_k.")
+
+    k_range = range(2, max_k_test + 1)
+
+    results_df, error = get_kmeans_elbow_silhouette_data(sample_feature_df, k_range=k_range, scale_data=True)
+    assert error is None
+    assert results_df is not None
+    assert 'K' in results_df.columns
+    assert 'Inertia' in results_df.columns
+    assert 'Silhouette Score' in results_df.columns
+    assert len(results_df) == len(k_range)
+
+def test_perform_dbscan_clustering_basic(sample_feature_df):
+    from src.analysis_modules.clustering import perform_dbscan_clustering
+    # DBSCAN parameters are sensitive, these are just for a smoke test
+    labels, model, error = perform_dbscan_clustering(sample_feature_df, eps=1.0, min_samples=3, scale_data=True)
+    assert error is None
+    assert labels is not None
+    assert model is not None
+    assert len(labels) == len(sample_feature_df)
+    assert isinstance(labels, pd.Series)
+
+def test_perform_dbscan_clustering_edge_cases():
+    from src.analysis_modules.clustering import perform_dbscan_clustering
+    # Empty DataFrame
+    labels, model, error = perform_dbscan_clustering(pd.DataFrame())
+    assert "Input DataFrame is empty" in error
+    assert labels is None
+    assert model is None
+
+    # NaN DataFrame
+    nan_df = pd.DataFrame({'A': [1, np.nan], 'B': [2,3]})
+    labels, model, error = perform_dbscan_clustering(nan_df)
+    assert "Input DataFrame contains NaN values" in error
+    assert labels is None
+    assert model is None
+
+# Placeholder test can be removed or adapted if ClusteringAnalysisModule tests are added later
 def test_placeholder():
     assert True
-
-# Attempt to absorb extraneous characters
-"""
-```
-"""
-```


### PR DESCRIPTION
- Corrected relative imports in src/main.py to resolve ModuleNotFoundError.
- Removed extraneous characters from tests/test_clustering.py.
- Added unit tests for perform_kmeans_clustering, get_kmeans_elbow_silhouette_data, and perform_dbscan_clustering in tests/test_clustering.py to cover basic functionality and edge cases.