### PR TITLE
Fix: Update actions/create-issue to v4 in workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Create Issue on Test Failure
       if: steps.pytest.outcome == 'failure'
-      uses: actions/create-issue@v2
+      uses: actions/create-issue@v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         title: "Unit Test Failures on main branch"


### PR DESCRIPTION
Changed the version of the actions/create-issue GitHub Action from v2 to v4 to resolve the 'action not found' error.