### PR TITLE
Feat: Include pytest logs in created GitHub issue

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -30,7 +30,8 @@ jobs:
       id: pytest
       run: |
         export PYTHONPATH=${{ github.workspace }}
-        pytest
+        # Run pytest, save output to a file, and also print to console. Preserve exit code.
+        pytest 2>&1 | tee pytest_output.log; exit ${PIPESTATUS[0]}
       # Continue on error so the next step can create an issue
       continue-on-error: true
 
@@ -41,6 +42,11 @@ jobs:
         {
           echo "The unit tests failed. Please investigate."
           echo "- Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo ""
+          echo "## Pytest Output:"
+          echo "\`\`\`"
+          cat pytest_output.log || echo "pytest_output.log not found or empty."
+          echo "\`\`\`"
         } > .github/ISSUE_BODY.md
 
     - name: Create Issue from File on Test Failure


### PR DESCRIPTION
Updated the GitHub Actions workflow to:
- Capture stdout and stderr from the pytest run into a file (pytest_output.log).
- Include the content of pytest_output.log within the body of the GitHub issue created upon test failure.
- Ensure the original pytest exit code is preserved for step outcome evaluation.